### PR TITLE
Updated Echo theme

### DIFF
--- a/items/echo/metadata.json
+++ b/items/echo/metadata.json
@@ -1,7 +1,7 @@
 {
 	"name": "Echo",
-	"version": "1.0",
-	"release_date": "2018-01-02",
+	"version": "3.5",
+	"release_date": "2018-12-19",
 	"license": "GPL-3.0",
 	"price_usd": "0",
 	"download_url": "https://github.com/marekrost/echo/archive/master.zip",
@@ -9,25 +9,25 @@
 	"information_url": "https://github.com/marekrost/echo",
 	"credits": "",
 	"credits_url": "",
-	"description": "Bludit and Bootstrap 3 version of original Echo theme for Nibbleblog by Diego Najar.",
+	"description": "Bludit and Bootstrap 4 version of original Echo theme for Nibbleblog by Diego Najar.",
 	"features": {
 		"0": "Lightweight.",
 		"1": "Responsive design.",
 		"2": ""
 	},
-	"description_de": "",
+	"description_de": "Bludit und Bootstrap 4-Version des ursprünglichen Echo-Theme für Nibbleblog von Diego Najar.",
 	"features_de": {
-		"0": "",
-		"1": "",
+		"0": "Leicht.",
+		"1": "Sich anpassendes Design.",
 		"2": ""
 	},
-	"description_es": "",
+	"description_es": "Bludit y Bootstrap 4 versión del tema original de Echo para Nibbleblog por Diego Najar.",
 	"features_es": {
 		"0": "",
 		"1": "",
 		"2": ""
 	},
-	"description_ru": "Bludit и Bootstrap версии 3 лежат в основе оригинальной темы Echo для проекта Nibbleblog Диего Наджара.",
+	"description_ru": "Bludit и Bootstrap версии 4 лежат в основе оригинальной темы Echo для проекта Nibbleblog Диего Наджара.",
 	"features_ru": {
 		"0": "Лёгкая",
 		"1": "Адаптивный под разные разрешения экранов дизайн.",


### PR DESCRIPTION
Hey Diego,

when i open this page: https://themes.bludit.com/theme/echo there is download button "Download for Bludit 2.x". I cannot see this button in metadata file.

This is what people should know:

For bludit 2.x they should download https://github.com/marekrost/echo/archive/v2.3.zip
For bludit 3.x they should download master branch: https://github.com/marekrost/echo/archive/master.zip

Can you set up the website, so people see the two download buttons?

Cheers Marek.